### PR TITLE
fix: don't set culture invariant mode

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,8 +110,7 @@ COPY --from=qemu /usr/bin/* /usr/bin
 ENV HEALTHCHECK_URL=http://localhost:8096/health
 
 # Default environment variables for the Jellyfin invocation
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
-    DEBIAN_FRONTEND="noninteractive" \
+ENV DEBIAN_FRONTEND="noninteractive" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \


### PR DESCRIPTION
We are not enabling culture invariant mode anywhere else, and the cultural related data is already included in our docker image as part of tha base installation, so enabling it does not even reduce the image size, but only brakes multi-language support for our new transliterator.

Fixes jellyfin/jellyfin#11213