### PR TITLE
Remove targz from macos build config

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -75,7 +75,7 @@ windows:
   imagename: jellyfin-builder-windows
 macos:
   build_function: build_macos
-  archivetypes: targz,tarxz
+  archivetypes: tarxz
   archmaps:
     amd64:
       DOTNET_ARCH: x64


### PR DESCRIPTION
Removes targz from the archive formats used for macOS.
All versions of macOS Jellyfin supports have native support for both targz and tarxz archives.
There is no need to provide both.