### PR TITLE
Switch to jellyfin-ffmpeg7 in Jellyfin 10.10

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,14 +10,14 @@ Vcs-Browser: https://github.com/jellyfin
 
 Package: jellyfin
 Architecture: all
-Depends: jellyfin-server, jellyfin-web, jellyfin-ffmpeg6
+Depends: jellyfin-server, jellyfin-web, jellyfin-ffmpeg7
 Description: Jellyfin is the Free Software Media System.
  This metapackage provides the core Jellyfin components from one name.
 
 Package: jellyfin-server
 Architecture: any
 Depends: libfontconfig1, adduser
-Recommends: jellyfin-web, sudo, ffmpeg | jellyfin-ffmpeg6
+Recommends: jellyfin-web, sudo, ffmpeg | jellyfin-ffmpeg7
 Description: Jellyfin is the Free Software Media System.
  This package provides the Jellyfin server backend and API.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ARG NODEJS_VERSION=20
 ARG OS_VERSION=bookworm
 
 # Jellyfin FFMPEG package
-ARG FFMPEG_PACKAGE=jellyfin-ffmpeg6
+ARG FFMPEG_PACKAGE=jellyfin-ffmpeg7
 
 # https://github.com/intel/compute-runtime/releases
 ARG GMMLIB_VERSION=22.4.1

--- a/portable/build.sh
+++ b/portable/build.sh
@@ -7,7 +7,7 @@ set -o xtrace
 
 # Set global variables
 REPOSITORY_URI="https://repo.jellyfin.org"
-FFMPEG_VERSION="6.x"
+FFMPEG_VERSION="7.x"
 
 # Create the intermediate build dir
 BUILD_DIR="/build"

--- a/portable/build.sh
+++ b/portable/build.sh
@@ -77,7 +77,7 @@ case ${BUILD_TYPE}-${PACKAGE_ARCH} in
 #        rm ffmpeg.tar.xz
 #    ;;
     windows-amd64)
-        FFMPEG_PATH=$( curl ${REPOSITORY_URI}/?path=/ffmpeg/windows/latest-${FFMPEG_VERSION}/win64 | grep -o "/files/.*-portable_win64.zip'" | sed "s/'$//" )
+        FFMPEG_PATH=$( curl ${REPOSITORY_URI}/?path=/ffmpeg/windows/latest-${FFMPEG_VERSION}/win64 | grep -o "/files/.*-portable_win64-clang-gpl.zip'" | sed "s/'$//" )
         curl --location --output ffmpeg.zip ${REPOSITORY_URI}${FFMPEG_PATH}
         unzip ffmpeg.zip
         rm ffmpeg.zip


### PR DESCRIPTION
Merge this when jellyfin-ffmpeg7 `7.0.2-1` is released.

- Switch to jellyfin-ffmpeg7
- Use Windows FFmpeg built with Clang