### PR TITLE
Fix incorrect windows ffmpeg path

### DIFF
--- a/portable/build.sh
+++ b/portable/build.sh
@@ -77,7 +77,7 @@ case ${BUILD_TYPE}-${PACKAGE_ARCH} in
 #        rm ffmpeg.tar.xz
 #    ;;
     windows-amd64)
-        FFMPEG_PATH=$( curl ${REPOSITORY_URI}/?path=/ffmpeg/windows/latest-${FFMPEG_VERSION}/win64 | grep -o "/files/.*-portable_win64-clang-gpl.zip'" | sed "s/'$//" )
+        FFMPEG_PATH=$( curl ${REPOSITORY_URI}/?path=/ffmpeg/windows/latest-${FFMPEG_VERSION}/win64 | grep -o "/files/.*_portable_win64-clang-gpl.zip'" | sed "s/'$//" )
         curl --location --output ffmpeg.zip ${REPOSITORY_URI}${FFMPEG_PATH}
         unzip ffmpeg.zip
         rm ffmpeg.zip


### PR DESCRIPTION
In Clang ffmpeg, there should be an underscore, not a dash. cc @joshuaboniface

Fixes https://github.com/jellyfin/jellyfin-packaging/issues/40