### PR TITLE
Add support for rootless files management

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -190,8 +190,8 @@ RUN if test "${PACKAGE_ARCH}" = "arm64"; then \
 RUN mkdir -p ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
  && chmod 777 ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
 
-COPY --from=server /server /jellyfin
-COPY --from=web /web /jellyfin/jellyfin-web
+COPY --from=server --chown=1000:1000 --chmod=755 /server /jellyfin
+COPY --from=web --chown=1000:1000 --chmod=755 /web /jellyfin/jellyfin-web
 
 ARG JELLYFIN_VERSION
 LABEL "org.opencontainers.image.source"="https://github.com/jellyfin/jellyfin"


### PR DESCRIPTION
When using the official container, there is no possibility for the app to write files related to the frontend or even itself. The main use case is being able to install the Intro Skip plugin when running Jellyfin in rootless mode. I arbitrarily hard-coded 1000:1000, but it should be fine as a sane default. The best of the best would be to have a script running as root as the beginning, but then exec'ing into Jellyfin with the proper UID and GID set. But this should do in the meantime.

Note that this could create a security issue since the app can modify itself or allow an extension to modify the frontend when running. That said, this flaw already exists for all the users running Jellyfin as root in the container. This should be fine for most cases, and there is still the possibility of running as another UID/GID to make sure to deny write access.