### PR TITLE
Ignore proxy settings during healthcheck

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -206,4 +206,4 @@ VOLUME ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
 ENTRYPOINT ["/jellyfin/jellyfin"]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 \
-     CMD curl --noproxy '*' -Lk -fsS "${HEALTHCHECK_URL}" || exit 1
+     CMD curl --noproxy 'localhost' -Lk -fsS "${HEALTHCHECK_URL}" || exit 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -206,4 +206,4 @@ VOLUME ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
 ENTRYPOINT ["/jellyfin/jellyfin"]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 \
-     CMD curl -Lk -fsS "${HEALTHCHECK_URL}" || exit 1
+     CMD curl --noproxy '*' -Lk -fsS "${HEALTHCHECK_URL}" || exit 1


### PR DESCRIPTION
Currently if proxy server was passed into container with env variables http_proxy, https_proxy, health check fails. 
Proxy settings should be ignored during heath check.