### PR TITLE
Explicitly set the target platform of Docker builds

### DIFF
--- a/build.py
+++ b/build.py
@@ -309,6 +309,7 @@ def build_docker(
         DOTNET_ARCH = configurations["docker"]["archmaps"][_build_arch]["DOTNET_ARCH"]
         QEMU_ARCH = configurations["docker"]["archmaps"][_build_arch]["QEMU_ARCH"]
         IMAGE_ARCH = configurations["docker"]["archmaps"][_build_arch]["IMAGE_ARCH"]
+        TARGET_ARCH = configurations["docker"]["archmaps"][_build_arch]["TARGET_ARCH"]
 
         # Use a unique docker image name for consistency
         if is_stable:
@@ -327,10 +328,10 @@ def build_docker(
 
         # Build the dockerfile
         log(
-            f">>> {docker_build_cmd} --build-arg PACKAGE_ARCH={PACKAGE_ARCH} --build-arg DOTNET_ARCH={DOTNET_ARCH} --build-arg QEMU_ARCH={QEMU_ARCH} --build-arg IMAGE_ARCH={IMAGE_ARCH} --build-arg JELLYFIN_VERSION={jellyfin_version} --file {repo_root_dir}/{dockerfile} --tag {imagename} {repo_root_dir}"
+            f">>> {docker_build_cmd} --build-arg PACKAGE_ARCH={PACKAGE_ARCH} --build-arg DOTNET_ARCH={DOTNET_ARCH} --build-arg QEMU_ARCH={QEMU_ARCH} --build-arg IMAGE_ARCH={IMAGE_ARCH} --build-arg TARGET_ARCH={TARGET_ARCH} --build-arg JELLYFIN_VERSION={jellyfin_version} --file {repo_root_dir}/{dockerfile} --tag {imagename} {repo_root_dir}"
         )
         ret = os.system(
-            f"{docker_build_cmd} --build-arg PACKAGE_ARCH={PACKAGE_ARCH} --build-arg DOTNET_ARCH={DOTNET_ARCH} --build-arg QEMU_ARCH={QEMU_ARCH} --build-arg IMAGE_ARCH={IMAGE_ARCH} --build-arg JELLYFIN_VERSION={jellyfin_version} --file {repo_root_dir}/{dockerfile} --tag {imagename} {repo_root_dir}"
+            f"{docker_build_cmd} --build-arg PACKAGE_ARCH={PACKAGE_ARCH} --build-arg DOTNET_ARCH={DOTNET_ARCH} --build-arg QEMU_ARCH={QEMU_ARCH} --build-arg IMAGE_ARCH={IMAGE_ARCH} --build-arg TARGET_ARCH={TARGET_ARCH} --build-arg JELLYFIN_VERSION={jellyfin_version} --file {repo_root_dir}/{dockerfile} --tag {imagename} {repo_root_dir}"
         )
         if ret > 0:
             exit(1)

--- a/build.yaml
+++ b/build.yaml
@@ -100,16 +100,19 @@ docker:
       IMAGE_ARCH: amd64
       PACKAGE_ARCH: amd64
       QEMU_ARCH: x86_64
+      TARGET_ARCH: amd64
     arm64:
       DOTNET_ARCH: arm64
       IMAGE_ARCH: arm64v8
       PACKAGE_ARCH: arm64
       QEMU_ARCH: aarch64
+      TARGET_ARCH: arm64/v8
     armhf:
       DOTNET_ARCH: arm
       IMAGE_ARCH: arm32v7
       PACKAGE_ARCH: armhf
       QEMU_ARCH: arm
+      TARGET_ARCH: arm/v7
   dockerfile: docker/Dockerfile
   imagename: jellyfin/jellyfin
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,8 +25,10 @@ ARG PACKAGE_ARCH
 ARG DOTNET_ARCH
 # QEMU architecture (x86_64, aarch64, arm), set by build script
 ARG QEMU_ARCH
-# Base Image archiecture (amd64, arm64v8, arm32v7), set by build script
+# Base Image architecture (amd64, arm64v8, arm32v7), set by build script
 ARG IMAGE_ARCH
+# Target platform architecture (amd64, arm64/v8, arm/v7), set by build script
+ARG TARGET_ARCH
 
 # Jellyfin version
 ARG JELLYFIN_VERSION
@@ -86,7 +88,7 @@ RUN dotnet publish Jellyfin.Server --configuration Release \
 # Build the final combined image
 #
 FROM multiarch/qemu-user-static:x86_64-${QEMU_ARCH} as qemu
-FROM ${IMAGE_ARCH}/debian:${OS_VERSION}-slim as combined
+FROM --platform=linux/${TARGET_ARCH} ${IMAGE_ARCH}/debian:${OS_VERSION}-slim as combined
 
 ARG OS_VERSION
 ARG FFMPEG_PACKAGE


### PR DESCRIPTION
Recently an error popped up when I was building an `arm64` image on `amd64`:
```
#4 [internal] load metadata for docker.io/arm64v8/debian:bookworm-slim
#4 ERROR: no match for platform in manifest: not found

#3 [internal] load metadata for docker.io/library/node:20-alpine
#3 CANCELED

#5 [internal] load metadata for docker.io/multiarch/qemu-user-static:x86_64-aarch64
#5 CANCELED
------
 > [internal] load metadata for docker.io/arm64v8/debian:bookworm-slim:
------
Dockerfile:91
--------------------
  89 |     #
  90 |     FROM multiarch/qemu-user-static:x86_64-${QEMU_ARCH} as qemu
  91 | >>> FROM ${IMAGE_ARCH}/debian:${OS_VERSION}-slim as combined
  92 |
  93 |     ARG OS_VERSION
--------------------
ERROR: failed to solve: arm64v8/debian:bookworm-slim: failed to resolve source metadata for docker.io/arm64v8/debian:bookworm-slim: no match for platform in manifest: not found
```
https://github.com/uraimo/run-on-arch-action/issues/155
https://github.com/docker-library/python/issues/933#issuecomment-2195092083
> We've been slowly moving Official Images to a new build process and moved python yesterday, so now the arch-specific namespaces are an image index because they include attached provenance/sbom metedata.

It was caused by some upstream changes, where now the `FROM` directive requires you to explicitly set the platform type for multi-arch builds.

https://docs.docker.com/reference/dockerfile/#from
> The optional --platform flag can be used to specify the platform of the image in case FROM references a multi-platform image. For example, linux/amd64, linux/arm64, or windows/amd64. By default, the target platform of the build request is used.

Their documentation is also out of date and does not reflect this new behavior.