### PR TITLE
Clean up Debian package initialization scripts

### DIFF
--- a/debian/conf/jellyfin
+++ b/debian/conf/jellyfin
@@ -47,6 +47,9 @@ JELLYFIN_ADDITIONAL_OPTS=""
 # 1 = Server
 #COMPlus_gcServer=1
 
+# Uncomment this option to stop Jellyfin from auto-starting during package installation; for systemd, `mask` is preferred.
+#DISABLE_JELLYFIN_AUTOSTART="yes"
+
 #
 # SysV init/Upstart options
 #

--- a/debian/jellyfin-server.postinst
+++ b/debian/jellyfin-server.postinst
@@ -65,8 +65,6 @@ esac
 #DEBHELPER
 
 if [[ -x "/usr/bin/deb-systemd-helper" ]]; then
-  # Manual init script handling
-  deb-systemd-helper unmask jellyfin.service >/dev/null || true
   # was-enabled defaults to true, so new installations run enable.
   if deb-systemd-helper --quiet was-enabled jellyfin.service; then
     # Enables the unit on first installation, creates new
@@ -79,15 +77,17 @@ if [[ -x "/usr/bin/deb-systemd-helper" ]]; then
   fi
 fi
 
-# End automatically added section
-# Automatically added by dh_installinit
 if [[ "$1" == "configure" ]] || [[ "$1" == "abort-upgrade" ]]; then
   if [[ -d "/run/systemd/system" ]]; then
     systemctl --system daemon-reload >/dev/null || true
-    deb-systemd-invoke start jellyfin >/dev/null || true
+    if [[ -z ${DISABLE_JELLYFIN_AUTOSTART} ]]; then
+        deb-systemd-invoke start jellyfin >/dev/null || true
+    fi
   elif [[ -x "/etc/init.d/jellyfin" ]] || [[ -e "/etc/init/jellyfin.conf" ]]; then
-    update-rc.d jellyfin defaults >/dev/null
-    invoke-rc.d jellyfin start || exit $?
+    if [[ -z ${DISABLE_JELLYFIN_AUTOSTART} ]]; then
+        update-rc.d jellyfin defaults >/dev/null
+        invoke-rc.d jellyfin start || exit $?
+    fi
   fi
 fi
 exit 0

--- a/debian/jellyfin-server.postrm
+++ b/debian/jellyfin-server.postrm
@@ -31,7 +31,6 @@ case "$1" in
 
     if [[ -x "/usr/bin/deb-systemd-helper" ]]; then
       deb-systemd-helper purge jellyfin.service >/dev/null
-      deb-systemd-helper unmask jellyfin.service >/dev/null
     fi
 
     # Remove user and group
@@ -63,12 +62,7 @@ case "$1" in
     [[ -e /var/cache/jellyfin ]] && rm -rf /var/cache/jellyfin || true
     [[ -e /var/lib/jellyfin ]] && rm -rf /var/lib/jellyfin || true
     ;;
-  remove)
-    if [[ -x "/usr/bin/deb-systemd-helper" ]]; then
-      deb-systemd-helper mask jellyfin.service >/dev/null
-    fi
-    ;;
-  upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+  remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
     ;;
   *)
     echo "postrm called with unknown argument \`$1'" >&2

--- a/debian/jellyfin-server.preinst
+++ b/debian/jellyfin-server.preinst
@@ -50,21 +50,6 @@ case "$1" in
         [[ -f $PIDFILE ]] && rm $PIDFILE
       fi
     fi
-
-    # Clean up old Emby cruft that can break the user's system
-    [[ -f /etc/sudoers.d/emby ]] && rm -f /etc/sudoers.d/emby
-
-    # If we have existing config, log, or cache dirs in /var/lib/jellyfin, move them into the right place
-    if [[ -d $PROGRAMDATA/config ]]; then
-        mv $PROGRAMDATA/config $CONFIGDATA
-    fi
-    if [[ -d $PROGRAMDATA/logs ]]; then
-        mv $PROGRAMDATA/logs $LOGDATA
-    fi
-    if [[ -d $PROGRAMDATA/logs ]]; then
-        mv $PROGRAMDATA/cache $CACHEDATA
-    fi
-
     ;;
   abort-upgrade)
     ;;

--- a/debian/jellyfin-server.preinst
+++ b/debian/jellyfin-server.preinst
@@ -44,7 +44,7 @@ case "$1" in
       sleep 1
       # if it's still running, show error
       if [[ -n "$(ps -p $JELLYFIN_PID -o pid=)" ]]; then
-        echo "Could not successfully stop JellyfinServer, please do so before uninstalling."
+        echo "Could not successfully stop Jellyfin, please do so before installing."
         exit 1
       else
         [[ -f $PIDFILE ]] && rm $PIDFILE


### PR DESCRIPTION
This PR cleans up 3 aspects of the Jellyfin service handling in `jellyfin-server.*` scripts that were possibly problematic.

1. Removes a bunch of legacy cruft from `jellyfin-server.preinst`, specifically trying to remove the Emby `sudoers` config and trying to move config/data directories around. These were *very* legacy migrations that should no longer be relevant.

2. Remove any references to masking/unmasking services in `postinst` and `postrm`. Masking is not something the package config should be touching, as this is administrator intervention. This also ensures that `systemctl mask jellyfin` can be used to *reliably* disable Jellyfin on `systemd` systems.

3. Add a new option to the service definition config called `DISABLE_JELLYFIN_AUTOSTART`. If uncommented (i.e. non-empty), will prevent the automatic service start (but not the stop). This should act as a reliable second way to ensure Jellyfin doesn't start during package install should the administrator so choose.

Also fixes up a warning message during `preinst` if we can't stop the service, to make it nicer.

Fixes #50 