### PR TITLE
Simplify dotnet publish

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,9 +85,9 @@ WORKDIR ${SOURCE_DIR}
 COPY jellyfin-server .
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-RUN dotnet publish Jellyfin.Server --configuration Release \
+RUN dotnet publish Jellyfin.Server --arch ${DOTNET_ARCH} \
     --output="${ARTIFACT_DIR}" --self-contained \
-    --runtime linux-${DOTNET_ARCH} -p:DebugSymbols=false -p:DebugType=none
+    -p:DebugSymbols=false -p:DebugType=none
 
 #
 # Build the final combined image


### PR DESCRIPTION
This change should have the same result as before.

- Release is the default for publish
- Only `--arch` needs to be specified if the environment matches the target
- I built the image before and after, cleanly.