### PR TITLE
Add setting .NET version for nuget packages

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -12,6 +12,9 @@ on:
         type: string
         description: 'The server and web stable release tag ("vX.Y.Z") or "master"'
 
+env:
+  SDK_VERSION: "9.0.x"
+
 permissions:
   contents: read
 
@@ -768,6 +771,11 @@ jobs:
         run: |-
           sudo apt-get update
           sudo apt-get install --yes python3-git python3-yaml
+
+      - name: "Setup .NET"
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: ${{ env.SDK_VERSION }}
 
       - name: "Checkout repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Haven't had a nuget deployment since we upgraded to .NET 9 :upside_down_face: 