### PR TITLE
Add missing libicu dependency to control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Description: Jellyfin is the Free Software Media System.
 
 Package: jellyfin-server
 Architecture: any
-Depends: libfontconfig1, libjemalloc2, adduser
+Depends: libfontconfig1, libjemalloc2, adduser, libicu66 | libicu67 | libicu70 | libicu72 | libicu74 | libicu76
 Recommends: jellyfin-web, sudo, jellyfin-ffmpeg7 | ffmpeg
 Description: Jellyfin is the Free Software Media System.
  This package provides the Jellyfin server backend and API.


### PR DESCRIPTION
Hello,
This pull request fixes the issue #77 . Unfortunately, the dependency on libxml2 has been removed, which means that the package is missing in Debian Trixie.