### PR TITLE
Install east asian fonts while building the docker, to make sure east asian subtitle rendered correctly.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -208,6 +208,21 @@ RUN if test "${PACKAGE_ARCH}" = "arm64"; then \
  && apt-get autoremove --yes \
  && rm -rf /var/cache/apt/archives* /var/lib/apt/lists/*
 
+# Add fonts for east asian languages rendering
+RUN apt update --yes \
+ && apt install --no-install-recommends --no-install-suggests --yes \
+        fonts-wqy-zenhei \
+        fonts-wqy-microhei \
+        fonts-arphic-ukai \
+        fonts-arphic-uming \
+        fonts-noto-cjk \
+        fonts-ipafont-mincho \
+        fonts-ipafont-gothic \
+        fonts-unfonts-core \
+ && apt clean autoclean --yes \
+ && apt autoremove --yes \
+ && rm -rf /var/cache/apt/archives* /var/lib/apt/lists/*
+
 # Setup jemalloc: link the library to a path owned by us to handle arch specific library paths
 RUN mkdir -p /usr/lib/jellyfin \
   && JEMALLOC_LINKED=0 \


### PR DESCRIPTION
### Problem

In the original docker build, when there are subtitles involving east asian characters like Chinese, Japanese and Korean, it will fail to render. It can be partly fixed by adding custom fallback fonts; however, when running transcoding, these fallback fonts might fail to be applied.

### Solution
In this PR, we install the most basic fonts for each asian language, which at least guarantees that there is a usable, maybe not fancy, and readable fonts when running transcoding the subtitle on the server.

