### PR TITLE
State dotnet-sdk-9.0 dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: misc
 Priority: optional
 Maintainer: Jellyfin Packaging Team <packaging@jellyfin.org>
 Build-Depends:  debhelper (>= 10),
-                npm | nodejs,
+                npm | nodejs, dotnet-sdk-9.0
 Standards-Version: 3.9.4
 Homepage: https://jellyfin.org
 Vcs-Browser: https://github.com/jellyfin


### PR DESCRIPTION
- We [used to do that](https://github.com/jellyfin/jellyfin-packaging/commit/7666f4d8) during the .NET 8 era
- Now that [installing .NET out of packages on Ubuntu is supported once again](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet9&pivots=os-linux-ubuntu-2404), maybe this is the path of least astonishment for Ubuntu-based contributors.