### PR TITLE
Add support for Node 24 LTS jellyfin-web

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -16,6 +16,7 @@ frameworks:
   jellyfin-web:
     NODEJS_VERSION:
       6c0a64ef12b9eb40a7c4ee4b9d43d0a5f32f2287: 20  # Default
+      2a7006502aa2b71d705683040a5c644ab4edaf1e: 24
   jellyfin-server:
     DOTNET_VERSION:
       6d1abf67c36379f0b061095619147a3691841e21: 8.0  # Default


### PR DESCRIPTION
Adds support for Node 24 LTS jellyfin-web, as Node 20 is EOL in April.

<img width="1553" height="903" alt="Screenshot From 2026-01-11 12-00-02" src="https://github.com/user-attachments/assets/12b515fe-1453-4754-9211-7c2bf64a837a" />

Required for the following:
- https://github.com/jellyfin/jellyfin-web/pull/7282