### PR TITLE
Define optional Jellyfin service arguments

### DIFF
--- a/debian/conf/jellyfin
+++ b/debian/conf/jellyfin
@@ -38,9 +38,11 @@ MALLOC_TRIM_THRESHOLD_=131072
 
 # [OPTIONAL] run Jellyfin as a headless service
 #JELLYFIN_SERVICE_OPT="--service"
+JELLYFIN_SERVICE_OPT=""
 
 # [OPTIONAL] run Jellyfin without the web app
 #JELLYFIN_NOWEBAPP_OPT="--nowebclient"
+JELLYFIN_NOWEBAPP_OPT=""
 
 # Space to add additional command line options to jellyfin (for help see ~$ jellyfin --help)
 JELLYFIN_ADDITIONAL_OPTS=""


### PR DESCRIPTION
## Summary
- define optional service and no-webapp argument variables as empty defaults
- keep the commented examples for enabling either optional flag
- avoid systemd warnings when the default unit expands those variables

## Testing
- `sh -n debian/conf/jellyfin`
- `env -i sh -c '. debian/conf/jellyfin; test "${JELLYFIN_SERVICE_OPT+x}" = x; test "${JELLYFIN_NOWEBAPP_OPT+x}" = x'`
