### PR TITLE
Exclude libpdfium.so from dh_strip

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -41,6 +41,12 @@ override_dh_gencontrol:
 
 override_dh_auto_test:
 
+# libpdfium.so is a prebuilt third-party binary carrying an 8-byte GNU build ID,
+# which the runner's debugedit cannot rewrite ("Cannot handle 8-byte build ID"),
+# aborting dh_strip. It is already stripped, so exclude it from dh_strip entirely.
+override_dh_strip:
+	dh_strip -Xlibpdfium.so
+
 override_dh_clistrip:
 
 override_dh_auto_build:


### PR DESCRIPTION
## Problem

Debian package builds (e.g. the `v12.0` preview) fail during `dh_strip`:

```
debugedit: Cannot handle 8-byte build ID
dh_strip: error: debugedit --build-id --build-id-seed=jellyfin-server/12.0-rc3+ubu2204 debian/jellyfin-server/usr/lib/jellyfin/bin/libpdfium.so returned exit code 1
dh_strip: error: Aborting due to earlier error
make: *** [debian/rules:35: binary] Error 25
```

The compile itself succeeds — the failure is purely in packaging. Because `dh_strip` aborts, no `.deb` is produced, which then surfaces as a downstream `debsigs`/`File out/ubuntu/*.deb does not exist` error.

## Root cause

`libpdfium.so` is a prebuilt third-party PDF library carrying an 8-byte GNU build ID. The `debugedit` version on the Ubuntu 22.04 build runner only handles the standard 20-byte build IDs, so it crashes when `dh_strip` tries to rewrite the build-id.

## Fix

Add an `override_dh_strip` that excludes `libpdfium.so` via `-X`. The library is a prebuilt, already-stripped binary, so there is nothing to gain from stripping it. This is the only place `dh_strip` runs — the native and Docker-based Debian builds both use this single `debian/rules`, and there is no RPM/Fedora build path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)