### PR TITLE
Install libdrm2 for GPU OpenCL dependencies in the combined image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -170,6 +170,7 @@ RUN apt-get update \
     libfontconfig1 \
     libfreetype6 \
     libjemalloc2 \
+    libdrm2 \
  && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen \
  && apt-get remove gnupg apt-transport-https --yes \
  && apt-get clean autoclean --yes \


### PR DESCRIPTION
## Problem

The arm64 Docker image build fails while installing the libmali-rockchip `.deb`:

```
libmali-valhall-g610-g24p0-gbm : Depends: libdrm2 (>= 2.4.31) but it is not installable
E: Unable to correct problems, you have held broken packages.
... did not complete successfully: exit code: 100
```

The `.deb` downloads fine — the failure is dependency resolution.

## Root cause

The GPU driver steps install a downloaded `.deb` via `apt-get install -f`, relying on apt to pull in its dependencies. But the preceding `RUN` (the shared runtime-dependency install) ends with `rm -rf /var/lib/apt/lists/*`, so apt has no package index and cannot locate `libdrm2` — hence "not installable". `libdrm2` is not otherwise installed in the `combined` image, so the libmali dependency goes unsatisfied.

## Fix

`libdrm2` is a runtime GPU/DRM library required by the libmali (arm64) and Intel (amd64) OpenCL drivers. Add it to the explicit runtime dependency install in the `combined` stage, alongside the other shared libraries (`libfontconfig1`, `libfreetype6`, `libjemalloc2`, …). The GPU `.deb` steps then resolve their dependency from the already-installed package, with no need to re-fetch apt lists.

One-line change; keeps the existing single-layer `apt-get update && install && rm lists` pattern intact.

## Testing

Reproduced and verified the resolution on an emulated arm64 `debian:trixie-slim`, replaying the combined-stage dependency install (with the `apt lists` removed, as in CI) followed by the libmali `.deb` install — fails without `libdrm2`, succeeds with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)