### PR TITLE
Remove obsole LTS distros

### DIFF
--- a/.github/workflows/preview-build.yaml
+++ b/.github/workflows/preview-build.yaml
@@ -58,7 +58,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - bullseye
           - bookworm
           - trixie
         arch:
@@ -135,7 +134,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - focal
           - jammy
           - noble
           - resolute

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -53,7 +53,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - bullseye
           - bookworm
           - trixie
         arch:
@@ -165,7 +164,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - focal
           - jammy
           - noble
           - resolute

--- a/.github/workflows/unstable-build.yaml
+++ b/.github/workflows/unstable-build.yaml
@@ -52,7 +52,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - bullseye
           - bookworm
           - trixie
         arch:
@@ -165,7 +164,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - focal
           - jammy
           - noble
           - resolute

--- a/build.yaml
+++ b/build.yaml
@@ -26,7 +26,6 @@ frameworks:
 # DEB packages
 debian:
   releases:
-    bullseye: '11'
     bookworm: '12'
     trixie: '13'
   archmaps:
@@ -37,7 +36,6 @@ debian:
       PACKAGE_ARCH: arm64
       GCC_ARCH: aarch64
   cross-gcc:
-    bullseye: '10'
     bookworm: '12'
     trixie: '14'
   build_function: build_package_deb
@@ -45,7 +43,6 @@ debian:
   imagename: jellyfin-builder-debian
 ubuntu:
   releases:
-    focal: '20.04'
     jammy: '22.04'
     noble: '24.04'
     resolute: '26.04'
@@ -57,7 +54,6 @@ ubuntu:
       PACKAGE_ARCH: arm64
       GCC_ARCH: aarch64
   cross-gcc:
-    focal: '10'
     jammy: '12'
     noble: '13'
     resolute: '14'


### PR DESCRIPTION
Remove Debian Bullseye and Ubuntu Focal as they are no longer supported.