### PR TITLE
Use master mirror for Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -154,7 +154,7 @@ RUN apt-get update \
   | gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg \
  && cat <<EOF > /etc/apt/sources.list.d/jellyfin.sources
 Types: deb
-URIs: https://repo.jellyfin.org/debian
+URIs: https://repo.jellyfin.org/master/debian
 Suites: ${OS_VERSION}
 Components: main
 Architectures: ${PACKAGE_ARCH}


### PR DESCRIPTION
Pulling the Mirrorbits-directed `https:/repo.jellyfin.org/debian` during release Docker builds often results in a race condition, since the mirrors are in the process of updating due to the other parallel builds. This in turn causes the Docker build to error out around 8-9 minutes in.

Use the `/master/debian` Mirrorbits bypass path as the default instead, which prevents this situation.

This may cause some self-built Docker images to build a little slower around this step, especially if they're outside of North America, but it should be relatively minor and only affects pulling this one package for FFmpeg.